### PR TITLE
[codex] Añade publicación estática del frontend

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Angular demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proyecto
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: proyecto/package-lock.json
+      - run: npm ci
+      - run: npm test -- --watch=false --browsers=ChromeHeadless
+      - run: npm run build -- --configuration demo
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: proyecto/dist/proyecto/browser
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Objetivo
+
+Mantener el TFG ejecutable con backend R real en local y navegable como publicación estática de portfolio.
+
+## Reglas
+
+- La configuración `production` conserva el backend real; la configuración `demo` usa exclusivamente `demo.interceptor.ts`.
+- La publicación no ejecuta R, no sube archivos y no persiste usuarios.
+- Toda ruta HTTP nueva debe implementarse también en el interceptor o fallar explícitamente con 404.
+- No introducir credenciales ni tokens en el repositorio.
+- Actualizar `docs/portfolio_deployment.md` y `portfolio.json` cuando cambie la URL pública.
+
+## Verificación mínima
+
+```powershell
+cd .\proyecto
+npm ci
+npm test -- --watch=false --browsers=ChromeHeadless
+npm run build -- --configuration demo
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Leer y aplicar `AGENTS.md`. La guía canónica de publicación es `docs/portfolio_deployment.md`.

--- a/docs/portfolio_deployment.md
+++ b/docs/portfolio_deployment.md
@@ -1,0 +1,23 @@
+# Publicación estática del TFG
+
+## Propósito
+
+La publicación en GitHub Pages conserva la interfaz Angular del TFG y permite recorrer autenticación, gestión y ejecución de programas sin exponer el backend Plumber ni ejecutar código R recibido desde Internet.
+
+## Arquitectura
+
+La configuración `demo` reemplaza `environment.ts`, activa navegación con hash y registra `demo.interceptor.ts`. El interceptor responde a la lista cerrada de endpoints del frontend con fixtures en memoria. Cualquier endpoint no previsto devuelve 404 y nunca se delega a `localhost`.
+
+La configuración local normal conserva el comportamiento original con Docker Compose y backend R.
+
+## Despliegue
+
+El workflow `.github/workflows/pages.yml` instala desde `package-lock.json`, ejecuta tests, construye Angular con `--configuration demo` y publica `proyecto/dist/proyecto/browser`.
+
+URL prevista: `https://alonsomarcosm.github.io/TFG_AlonsoMarcosMu-oz/`.
+
+## Limitaciones
+
+Login, registro, subida, borrado y ejecución son interacciones simuladas. La finalidad es enseñar la interfaz y el contrato funcional, no ofrecer ejecución remota pública.
+
+Última verificación local: 2026-06-22.

--- a/portfolio.json
+++ b/portfolio.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "repository": "AlonsoMarcosM/TFG_AlonsoMarcosMu-oz",
+  "repository_url": "https://github.com/AlonsoMarcosM/TFG_AlonsoMarcosMu-oz",
+  "title": {
+    "es": "Ejecución remota de programas R",
+    "en": "Remote R Program Execution"
+  },
+  "summary": {
+    "es": "Frontend Angular para gestionar y ejecutar programas R mediante una API Plumber.",
+    "en": "Angular frontend to manage and execute R programs through a Plumber API."
+  },
+  "technologies": ["Angular", "TypeScript", "RxJS", "R", "Plumber", "Docker"],
+  "deployment": {
+    "type": "interactive",
+    "provider": "github-pages",
+    "mode": "static-mock",
+    "source_branch": "main",
+    "status": "prepared",
+    "url": "https://alonsomarcosm.github.io/TFG_AlonsoMarcosMu-oz/"
+  }
+}

--- a/proyecto/angular.json
+++ b/proyecto/angular.json
@@ -48,6 +48,16 @@
               ],
               "outputHashing": "all"
             },
+            "demo": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.demo.ts"
+                }
+              ],
+              "baseHref": "/TFG_AlonsoMarcosMu-oz/",
+              "outputHashing": "all"
+            },
             "development": {
               "optimization": false,
               "extractLicenses": false,

--- a/proyecto/src/app/auth/login/login.component.ts
+++ b/proyecto/src/app/auth/login/login.component.ts
@@ -9,6 +9,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-login',
@@ -32,6 +33,9 @@ import { MatIconModule } from '@angular/material/icon';
           </div>
         </mat-card-header>
         <mat-card-content>
+          <p class="demo-note" *ngIf="demoMode">
+            Publicación de portfolio: las credenciales están precargadas y todas las operaciones son simuladas.
+          </p>
           <form (ngSubmit)="login()">
             <mat-form-field appearance="outline" class="full-width">
               <mat-label>Usuario</mat-label>
@@ -112,11 +116,18 @@ import { MatIconModule } from '@angular/material/icon';
       color: #3f51b5;
       font-weight: bold;
     }
+    .demo-note {
+      color: #284b63;
+      background: #e9f5ff;
+      border-left: 4px solid #1976d2;
+      padding: 0.75rem;
+    }
   `]
 })
 export class LoginComponent {
-  usuario: string = '';
-  contrasena: string = '';
+  readonly demoMode = environment.demoMode;
+  usuario: string = environment.demoMode ? 'demo-admin' : '';
+  contrasena: string = environment.demoMode ? 'portfolio' : '';
   errorMessage: string = '';
 
   constructor(private authService: AuthService, private router: Router) {}

--- a/proyecto/src/app/core/demo.interceptor.spec.ts
+++ b/proyecto/src/app/core/demo.interceptor.spec.ts
@@ -1,0 +1,48 @@
+import { HttpErrorResponse, HttpRequest, HttpResponse } from '@angular/common/http';
+
+import { DEMO_PROGRAMS, demoInterceptor } from './demo.interceptor';
+
+
+describe('demoInterceptor', () => {
+  it('devuelve el catálogo congelado sin llamar al backend', (done) => {
+    const request = new HttpRequest('GET', 'http://localhost:7617/programasinfo');
+
+    demoInterceptor(request, () => {
+      fail('No debe delegar una ruta simulada');
+      throw new Error('Delegación inesperada');
+    }).subscribe((event) => {
+      if (event instanceof HttpResponse) {
+        expect(event.body).toEqual(DEMO_PROGRAMS);
+        done();
+      }
+    });
+  });
+
+  it('simula el login y no persiste credenciales reales', (done) => {
+    const request = new HttpRequest('POST', 'http://localhost:7617/iniciarsesion', null);
+
+    demoInterceptor(request, () => {
+      fail('No debe delegar el login simulado');
+      throw new Error('Delegación inesperada');
+    }).subscribe((event) => {
+      if (event instanceof HttpResponse) {
+        expect(event.body).toEqual({ status: ['success'], token: ['portfolio-read-only'] });
+        done();
+      }
+    });
+  });
+
+  it('rechaza endpoints que no forman parte del contrato', (done) => {
+    const request = new HttpRequest('GET', 'http://localhost:7617/no-existe');
+
+    demoInterceptor(request, () => {
+      fail('No debe delegar una ruta no permitida en modo demo');
+      throw new Error('Delegación inesperada');
+    }).subscribe({
+      error: (error: HttpErrorResponse) => {
+        expect(error.status).toBe(404);
+        done();
+      },
+    });
+  });
+});

--- a/proyecto/src/app/core/demo.interceptor.ts
+++ b/proyecto/src/app/core/demo.interceptor.ts
@@ -1,0 +1,113 @@
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, delay, of, throwError } from 'rxjs';
+
+
+export const DEMO_PROGRAMS = [
+  {
+    id: ['resumen_clientes'],
+    nombre_programa: ['Resumen de clientes'],
+    nombre_archivo: ['resumen_clientes.R'],
+    proposito: ['Genera una tabla agregada por segmento de cliente.'],
+    parametros: ['limite'],
+    defaults: { limite: ['100'] },
+    prefill: true,
+    metodo: ['Agregación y resumen descriptivo con R.'],
+    resultado_esperado: ['Tabla con clientes, gasto medio y retención.'],
+    analisis_resultado: ['Permite comparar el comportamiento por segmento.'],
+    mensaje: ['Programa versionado y validado en el TFG.'],
+    tipo: ['table'],
+  },
+  {
+    id: ['estadisticas_ventas'],
+    nombre_programa: ['Estadísticas de ventas'],
+    nombre_archivo: ['estadisticas_ventas.R'],
+    proposito: ['Calcula indicadores descriptivos sobre una muestra de ventas.'],
+    parametros: ['periodo', 'region'],
+    defaults: { periodo: ['2025'], region: ['Centro'] },
+    prefill: true,
+    metodo: ['Estadística descriptiva.'],
+    resultado_esperado: ['Media, mediana, desviación y registros procesados.'],
+    analisis_resultado: ['Resume la distribución de ventas de la muestra.'],
+    mensaje: ['La publicación devuelve un resultado congelado y no ejecuta R.'],
+    tipo: ['json'],
+  },
+];
+
+function response(body: unknown, status = 200): Observable<HttpEvent<unknown>> {
+  return of(new HttpResponse({ body, status })).pipe(delay(120));
+}
+
+function executeResponse(request: HttpRequest<unknown>): Observable<HttpEvent<unknown>> {
+  const programId = request.params.get('programa');
+  if (programId === 'resumen_clientes') {
+    return response([
+      { segmento: 'Pyme', clientes: 42, gasto_medio: 1840, retencion: '91 %' },
+      { segmento: 'Empresa', clientes: 18, gasto_medio: 6230, retencion: '96 %' },
+      { segmento: 'Particular', clientes: 40, gasto_medio: 690, retencion: '84 %' },
+    ]);
+  }
+  const payload = {
+    mensaje: ['Estadísticas calculadas en modo de solo lectura.'],
+    resultados: {
+      registros_procesados: [1250],
+      media_ventas: [2184.35],
+      mediana_ventas: [1976.8],
+      desviacion_estandar: [483.12],
+    },
+  };
+  return request.responseType === 'blob'
+    ? response(new Blob([JSON.stringify(payload)], { type: 'application/json' }))
+    : response(payload);
+}
+
+export const demoInterceptor: HttpInterceptorFn = (
+  request: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+): Observable<HttpEvent<unknown>> => {
+  let path: string;
+  try {
+    path = new URL(request.url, window.location.origin).pathname;
+  } catch {
+    return next(request);
+  }
+
+  switch (path) {
+    case '/iniciarsesion':
+      return response({ status: ['success'], token: ['portfolio-read-only'] });
+    case '/esAdmin':
+      return response([true]);
+    case '/lanzarapi':
+      return response({ status: ['success'], puerto: [7617] });
+    case '/crearusuarioadmin':
+    case '/crearusuarionoadmin':
+      return response({ status: ['success'], message: ['Usuario simulado; no se ha persistido ningún dato.'] });
+    case '/programasinfo':
+      return response(DEMO_PROGRAMS);
+    case '/refresh':
+      return response({ status: ['success'] });
+    case '/ejecutar':
+      return executeResponse(request);
+    case '/upload':
+      return response({ status: ['success'], message: ['Carga simulada; el archivo no se ha enviado.'] });
+    case '/delete':
+      return response({ status: ['deleted'], file: [request.params.get('filename') ?? 'programa.R'] });
+    case '/usuariosactivos':
+      return response([
+        { usuario: ['demo-admin'], puerto: ['7618'] },
+        { usuario: ['analista'], puerto: ['7619'] },
+      ]);
+    case '/cerrarsesion':
+      return response({ status: ['success'] });
+    default:
+      return throwError(
+        () => new HttpErrorResponse({ status: 404, statusText: 'Endpoint no simulado', url: request.url }),
+      );
+  }
+};

--- a/proyecto/src/environments/environment.demo.ts
+++ b/proyecto/src/environments/environment.demo.ts
@@ -1,7 +1,6 @@
-
 export const environment = {
-  production: false,
-  demoMode: false,
+  production: true,
+  demoMode: true,
   apiHost: 'localhost',
   apiDefaultPort: 7617,
 };

--- a/proyecto/src/main.ts
+++ b/proyecto/src/main.ts
@@ -1,13 +1,18 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter, withHashLocation } from '@angular/router';
+import { provideHttpClient, withInterceptors, withInterceptorsFromDi } from '@angular/common/http';
 import { AppComponent } from './app/core/app.component';
 import { routes } from './app/core/app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { demoInterceptor } from './app/core/demo.interceptor';
+import { environment } from './environments/environment';
 
 bootstrapApplication(AppComponent, {
   providers: [
-    provideRouter(routes),
-    provideHttpClient(withInterceptorsFromDi()), provideAnimationsAsync()
+    provideRouter(routes, ...(environment.demoMode ? [withHashLocation()] : [])),
+    provideHttpClient(
+      environment.demoMode ? withInterceptors([demoInterceptor]) : withInterceptorsFromDi(),
+    ),
+    provideAnimationsAsync(),
   ]
 });


### PR DESCRIPTION
## Qué cambia

- añade una configuración Angular `demo` con navegación hash;
- concentra login, programas, ejecución, subida, borrado y usuarios en un interceptor de fixtures;
- publica el build estático mediante GitHub Pages;
- documenta el contrato de despliegue para futuros agentes.

## Motivo

El backend Plumber ejecuta código R y no debe exponerse gratuitamente en Internet. La versión pública mantiene el recorrido funcional sin ejecutar código ni persistir datos.

## Verificación

- `npm test -- --watch=false --browsers=ChromeHeadless`: 3 tests correctos;
- `npm run build -- --configuration demo`: build correcto;
- `base href`: `/TFG_AlonsoMarcosMu-oz/`.

Las vulnerabilidades mostradas por npm pertenecen al árbol heredado de Angular y no se modifican en este cambio quirúrgico.