### PR TITLE
[codex] Registra el despliegue público verificado

### DIFF
--- a/docs/portfolio_deployment.md
+++ b/docs/portfolio_deployment.md
@@ -20,4 +20,4 @@ URL prevista: `https://alonsomarcosm.github.io/TFG_AlonsoMarcosMu-oz/`.
 
 Login, registro, subida, borrado y ejecución son interacciones simuladas. La finalidad es enseñar la interfaz y el contrato funcional, no ofrecer ejecución remota pública.
 
-Última verificación local: 2026-06-22.
+Última verificación pública: 2026-06-22, respuesta HTTP 200 y workflow completo.

--- a/portfolio.json
+++ b/portfolio.json
@@ -16,7 +16,7 @@
     "provider": "github-pages",
     "mode": "static-mock",
     "source_branch": "main",
-    "status": "prepared",
+    "status": "live",
     "url": "https://alonsomarcosm.github.io/TFG_AlonsoMarcosMu-oz/"
   }
 }


### PR DESCRIPTION
Marca la publicación como activa después de completar el workflow de GitHub Pages y verificar una respuesta HTTP 200.